### PR TITLE
Flipbook: Bugfix to lod calculation (needed to adjust texelSizeLod pa…

### DIFF
--- a/Editor/Material/PSXMaterialUtils.cs
+++ b/Editor/Material/PSXMaterialUtils.cs
@@ -254,6 +254,7 @@ namespace HauntedPSX.RenderPipelines.PSX.Editor
             public static readonly string _REFLECTION_ON = "_REFLECTION_ON";
             public static readonly string _FOG_ON = "_FOG_ON";
             public static readonly string _DOUBLE_SIDED_ON = "_DOUBLE_SIDED_ON";
+            public static readonly string _LOD_REQUIRES_ADJUSTMENT = "_LOD_REQUIRES_ADJUSTMENT";
         }
 
         public static class Styles
@@ -431,6 +432,7 @@ namespace HauntedPSX.RenderPipelines.PSX.Editor
             SetupMaterialReflectionKeyword(material);
             SetupMaterialEmissionKeyword(material);
             SetupDoubleSidedKeyword(material);
+            SetupLodRequiresAdjustmentKeyword(material);
         }
 
         public static void ClearMaterialKeywords(Material material)
@@ -463,6 +465,22 @@ namespace HauntedPSX.RenderPipelines.PSX.Editor
             else
             {
                 material.DisableKeyword(Keywords._DOUBLE_SIDED_ON);
+            }
+        }
+
+        public static void SetupLodRequiresAdjustmentKeyword(Material material)
+        {
+            if (material == null) { throw new ArgumentNullException("material"); }
+
+            UVAnimationMode uvAnimationMode = (UVAnimationMode)material.GetFloat(PropertyIDs._UVAnimationMode);
+
+            if (uvAnimationMode == UVAnimationMode.Flipbook)
+            {
+                material.EnableKeyword(Keywords._LOD_REQUIRES_ADJUSTMENT);
+            }
+            else
+            {
+                material.DisableKeyword(Keywords._LOD_REQUIRES_ADJUSTMENT);
             }
         }
 

--- a/Runtime/Material/PSXLit/PSXLit.shader
+++ b/Runtime/Material/PSXLit/PSXLit.shader
@@ -87,6 +87,7 @@
             #pragma shader_feature _FOG_ON
             #pragma shader_feature _DOUBLE_SIDED_ON
             #pragma shader_feature _BLENDMODE_TONEMAPPER_OFF
+            #pragma shader_feature _LOD_REQUIRES_ADJUSTMENT
 
             // -------------------------------------
             // Unity defined keywords

--- a/Runtime/Material/PSXLit/PSXLitPass.hlsl
+++ b/Runtime/Material/PSXLit/PSXLitPass.hlsl
@@ -83,7 +83,7 @@ half4 LitPassFragment(Varyings i, FRONT_FACE_TYPE cullFace : FRONT_FACE_SEMANTIC
     float4 texelSizeLod;
     float lod;
     ComputeLODAndTexelSizeMaybeCallDDX(texelSizeLod, lod, uvColor, _MainTex_TexelSize);
-    uvColor = ApplyUVAnimationPixel(lod, uvColor, _UVAnimationMode, _UVAnimationParametersFrameLimit, _UVAnimationParameters);
+    uvColor = ApplyUVAnimationPixel(texelSizeLod, lod, uvColor, _UVAnimationMode, _UVAnimationParametersFrameLimit, _UVAnimationParameters);
 
     float4 color = _MainColor * SampleTextureWithFilterMode(TEXTURE2D_ARGS(_MainTex, sampler_MainTex), uvColor, texelSizeLod, lod);
 


### PR DESCRIPTION
…rameter as well). Also added a keyword _LOD_REQUIRES_ADJUSTMENT for handling the case where texture importer settings are used, but we are adjusting the uv for the flipbook and need to correct the lod.